### PR TITLE
Check alternative token name

### DIFF
--- a/main_windows.py
+++ b/main_windows.py
@@ -72,7 +72,7 @@ except Exception as e:
 
 found = False
 for cookie in cookies:
-    if cookie.name == "cookie_token":
+    if cookie.name == "cookie_token" or cookie.name == "ltoken":
         found = True
         break
 if not found:


### PR DESCRIPTION
Add alternative token name to check, seems like they changed the token name in the cookie, idk.
Is it bcs i run linux? Ran with firefox in the config.